### PR TITLE
show shipping subtotal

### DIFF
--- a/v2/src/modules/documents/services/templates/invoices/basic/parts/table.ts
+++ b/v2/src/modules/documents/services/templates/invoices/basic/parts/table.ts
@@ -12,18 +12,25 @@
 
 import { generateHr } from "./hr";
 import { t } from "i18next";
-import { OrderDTO, OrderLineItemDTO } from "@medusajs/framework/types"
+import { OrderDTO, OrderLineItemDTO } from "@medusajs/framework/types";
 import { getDecimalDigits } from "../../../../../utils/currency";
 import { BigNumber } from "@medusajs/framework/utils";
 
-function amountToDisplay(amount: number, currencyCode: string) : string {
+function amountToDisplay(amount: number, currencyCode: string): string {
   const decimalDigits = getDecimalDigits(currencyCode);
-  return `${(amount / Math.pow(10, decimalDigits)).toFixed(decimalDigits)} ${currencyCode.toUpperCase()}`;
+  return `${(amount / Math.pow(10, decimalDigits)).toFixed(
+    decimalDigits
+  )} ${currencyCode.toUpperCase()}`;
 }
 
-function amountToDisplayNormalized(amount: number, currencyCode: string) : string {
+function amountToDisplayNormalized(
+  amount: number,
+  currencyCode: string
+): string {
   const decimalDigits = getDecimalDigits(currencyCode);
-  return `${parseFloat(amount.toString()).toFixed(decimalDigits)} ${currencyCode.toUpperCase()}`;
+  return `${parseFloat(amount.toString()).toFixed(
+    decimalDigits
+  )} ${currencyCode.toUpperCase()}`;
 }
 
 function generateTableRow(
@@ -44,7 +51,12 @@ function generateTableRow(
     .text(lineTotal, 0, y, { align: "right" });
 }
 
-export function generateInvoiceTable(doc, y, order: OrderDTO, items: OrderLineItemDTO[]) {
+export function generateInvoiceTable(
+  doc,
+  y,
+  order: OrderDTO,
+  items: OrderLineItemDTO[]
+) {
   let i;
   const invoiceTableTop = y + 35;
 
@@ -60,7 +72,7 @@ export function generateInvoiceTable(doc, y, order: OrderDTO, items: OrderLineIt
   );
   generateHr(doc, invoiceTableTop + 20);
   doc.font("Regular");
-  
+
   for (i = 0; i < items.length; i++) {
     const item = items[i];
     const position = invoiceTableTop + (i + 1) * 30;
@@ -69,9 +81,15 @@ export function generateInvoiceTable(doc, y, order: OrderDTO, items: OrderLineIt
       position,
       item.title,
       item.subtitle,
-      amountToDisplayNormalized(item.unit_price / item.quantity, order.currency_code),
+      amountToDisplayNormalized(
+        item.unit_price / item.quantity,
+        order.currency_code
+      ),
       item.quantity,
-      amountToDisplayNormalized(Number(item.raw_unit_price.value), order.currency_code)
+      amountToDisplayNormalized(
+        Number(item.raw_unit_price.value),
+        order.currency_code
+      )
     );
 
     generateHr(doc, position + 20);
@@ -85,7 +103,10 @@ export function generateInvoiceTable(doc, y, order: OrderDTO, items: OrderLineIt
     "",
     t("invoice-table-shipping", "Shipping"),
     "",
-    amountToDisplayNormalized((order.shipping_total as BigNumber).numeric, order.currency_code)
+    amountToDisplayNormalized(
+      (order.shipping_subtotal as BigNumber).numeric,
+      order.currency_code
+    )
   );
 
   const taxPosition = subtotalPosition + 30;
@@ -96,7 +117,10 @@ export function generateInvoiceTable(doc, y, order: OrderDTO, items: OrderLineIt
     "",
     t("invoice-table-tax", "Tax"),
     "",
-    amountToDisplayNormalized((order.tax_total as BigNumber).numeric, order.currency_code)
+    amountToDisplayNormalized(
+      (order.tax_total as BigNumber).numeric,
+      order.currency_code
+    )
   );
 
   const duePosition = taxPosition + 45;
@@ -108,7 +132,10 @@ export function generateInvoiceTable(doc, y, order: OrderDTO, items: OrderLineIt
     "",
     t("invoice-table-total", "Total"),
     "",
-    amountToDisplayNormalized((order.total as BigNumber).numeric, order.currency_code)
+    amountToDisplayNormalized(
+      (order.total as BigNumber).numeric,
+      order.currency_code
+    )
   );
   doc.font("Regular");
 }


### PR DESCRIPTION
Before:
Linetems total+shipping+tax!=total
(with the example image 42+10+10+12,7+19,44!=91.44)
![image](https://github.com/user-attachments/assets/a3f362fa-c4ad-41df-9c53-33307a307b1a)

After:
Showing the right shipping fee (without tax)
(with the example image 42+10+10+10+19,44=91.44)
![image](https://github.com/user-attachments/assets/28365176-122d-4853-8917-cbbeea8535d7)
